### PR TITLE
Update to pymorphy2 fork and fix bug on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.16.0
 h5py<=3.9.0
-pymorphy2[fast]>=0.9.1
+pymorphy2[fast] @ git+https://github.com/pymorphy2-fork/pymorphy2@master
 onnxruntime<=1.15.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.0
 h5py<=3.9.0
 protobuf<=3.20.3
-pymorphy2[fast]>=0.9.1
+pymorphy2[fast] @ git+https://github.com/pymorphy2-fork/pymorphy2@master
 tensorflow<=2.2.2
 onnxruntime<=1.15.1
 keras2onnx<=1.7

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(name='stressrnn',
       keywords='nlp russian stress accent emphasis linguistic rnn lstm bilstm',
       author_email='ponomarevamawa@gmail.com (RusStress), vladsklim@gmail.com (StressRNN)',
       packages=['stressrnn'],
+      # Add py.typed to the package
+      package_data={'stressrnn': ['py.typed']},
       install_requires=requirements(),
       include_package_data=True,
       zip_safe=False)

--- a/stressrnn/exception_dictionary_wrapper.py
+++ b/stressrnn/exception_dictionary_wrapper.py
@@ -51,7 +51,7 @@ class ExceptionDictWrapper:
         several identical words with different stresses, they will all be added to the dictionary, and the stress positions will be
         specified in the order of reading the words. '''
 
-        with open(f_name_exception_dict, 'r') as f_exception_dict:
+        with open(f_name_exception_dict, 'r', encoding="utf-8") as f_exception_dict:
             for word in f_exception_dict:
                 word = word.strip('\n')
                 if DEF_STRESS_SYMBOL in word:


### PR DESCRIPTION
The pymorphy2 fork allows to install the project on Python 3.10+.

Additionally I added a parameter with the encoding when loading the exception dict that is needed for Windows (otherwise it crashes).